### PR TITLE
decouple from level-sublevel

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,18 +4,15 @@ var Transform = require('stream').Transform
 
 module.exports = Secondary;
 
-function Secondary(db, name, reduce) {
-  var sub = db.sublevel(name);
-
+function Secondary(db, sub, name, reduce) {
   if (!reduce) {
     reduce = function(value) {
       return value[name];
     };
   }
 
-  db.pre(function(change, add) {
+  db.hooks.pre(function(change, add) {
     if (change.type != 'put') return;
-
     add({
       type: 'put',
       key: reduce(change.value),


### PR DESCRIPTION
I wanted to use this with level-spaces, to minimize the amount of global state across levelup instances (e.g. from the level-spaces readme: `level-spaces is aimed at basic use-cases and does not introduce any versioning problems by modifying the original LevelUP instance`)

this proposes an api change to make it possible to pass in your own subdb. now the only thing required is that the subdb has been level-hooks-ified, so usage could be something like:

``` js
// NOTE secondary currently requires a level-hooks-ified instance as 1st arg
var usersDb = levelSpace(db, 'users')
hooks(usersDb) // TODO find non-mutating alternative to level-hooks
var byGithubId = Secondary(usersDb, levelSpace(usersDb, 'githubHandle'), 'handle')
```
