### PR TITLE
decouple from level-sublevel Roud 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,16 @@
     "test": "tape test/*.js"
   },
   "dependencies": {
-    "xtend": "~4.0.1",
-    "readable-stream": "~2.2.0"
+    "level-hooks": "^4.5.0",
+    "readable-stream": "~2.2.0",
+    "xtend": "~4.0.1"
   },
   "devDependencies": {
-    "tape": "*",
     "level-sublevel": "~6.6.1",
     "memdb": "1.3.1",
-    "multilevel": "~7.3.0"
+    "multilevel": "~7.3.0",
+    "subleveldown": "^2.1.0",
+    "tape": "*"
   },
   "keywords": [
     "level",

--- a/test/del.js
+++ b/test/del.js
@@ -6,9 +6,10 @@ var test = require('tape');
 test('del', function(t) {
   t.plan(5);
   var db = sub(level({ valueEncoding: 'json' }));
+  var idb = db.sublevel('title')
 
   var posts = db.sublevel('posts');
-  posts.byTitle = Secondary(posts, 'title');
+  posts.byTitle = Secondary(posts, idb, 'title');
 
   posts.put('1337', {
     title: 'a title',

--- a/test/get.js
+++ b/test/get.js
@@ -4,12 +4,16 @@ var sub = require('level-sublevel');
 var test = require('tape');
 
 test('get', function(t) {
-  t.plan(3);
+  t.plan(5);
   var db = sub(level({ valueEncoding: 'json' }));
+  var index = {
+    title: db.sublevel('title'),
+    len: db.sublevel('length')
+  }
 
   var posts = db.sublevel('posts');
-  posts.byTitle = Secondary(posts, 'title');
-  posts.byLength = Secondary(posts, 'length', function(post){
+  posts.byTitle = Secondary(posts, index.title, 'title');
+  posts.byLength = Secondary(posts, index.len, function(post){
     return post.body.length;
   });
 
@@ -24,6 +28,10 @@ test('get', function(t) {
     posts.byTitle.get('a title', function(err, _post) {
       t.error(err);
       t.deepEqual(_post, post);
+      posts.byLength.get(post.body.length, function(err, _post) {
+        t.error(err)
+        t.deepEqual(_post, post)
+      })
     });
   });
 });

--- a/test/multilevel.js
+++ b/test/multilevel.js
@@ -6,9 +6,10 @@ var multilevel = require('multilevel');
 
 test('multilevel', function(t) {
 	t.plan(3);
-	
+
 	var db = sub(level({ valueEncoding: 'json' }));
-	var byTitle = Secondary(db, 'title');
+	var idb = db.sublevel('title')
+	var byTitle = Secondary(db, idb, 'title');
 	var server = multilevel.server(byTitle);
 	var client = multilevel.client(byTitle.manifest);
 

--- a/test/subleveldown.js
+++ b/test/subleveldown.js
@@ -1,17 +1,19 @@
 var level = require('memdb');
 var Secondary = require('..');
-var sub = require('level-sublevel');
+var sub = require('subleveldown');
 var test = require('tape');
 
-test('read streams', function(t) {
+test('subleveldown', function(t) {
   t.plan(4);
-  var db = sub(level({ valueEncoding: 'json' }));
+  var db = level();
+  var idb = level();
+
   var index = {
-    title: db.sublevel('title'),
-    len: db.sublevel('length')
+    title: sub(idb, 'title', { valueEncoding: 'json' }),
+    len: sub(idb, 'length', { valueEncoding: 'json' })
   };
 
-  var posts = db.sublevel('posts');
+  var posts = sub(db, 'posts', { valueEncoding: 'json' });
   posts.byTitle = Secondary(posts, index.title, 'title');
   posts.byLength = Secondary(posts, index.len, function(post){
     return post.body.length;


### PR DESCRIPTION
This is another stab at #4 from 2014, but maybe its still interesting.  Are you still using this module?  Or has something better come out?  

I really want a separate index db backend, and it would also be nice to be able to use whatever sublevel solution you want.  This seems to achieve that! 

It still uses level-hooks, which is does icky mutation.  If someone comes up with a better, non-mutant hook wrapper, we can swap for that later.

What do you think?  cc @maxogden